### PR TITLE
As false is a valid value, we cannot use cannotBeEmpty() here

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -49,7 +49,7 @@ class Configuration implements ConfigurationInterface
                         ->integerNode('expire')->cannotBeEmpty()->defaultValue(0)->end()
                         ->scalarNode('path')->cannotBeEmpty()->defaultValue('/')->end()
                         ->scalarNode('domain')->cannotBeEmpty()->defaultValue(null)->end()
-                        ->booleanNode('secure')->cannotBeEmpty()->defaultFalse()->end()
+                        ->booleanNode('secure')->defaultFalse()->end()
                         ->arrayNode('set_on')
                             ->prototype('array')
                                 ->children()


### PR DESCRIPTION
Fixes #1.
