### PR TITLE
Making the bundle work with disabled csrf protection

### DIFF
--- a/DependencyInjection/CompilerPass/CsrfCompilerPass.php
+++ b/DependencyInjection/CompilerPass/CsrfCompilerPass.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * (c) Kévin Dunglas <dunglas@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Dunglas\AngularCsrfBundle\DependencyInjection\CompilerPass;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Removes csrf listeners when token manager isn't loaded
+ *
+ * @author Michal Dabrowski <dabrowski@brillante.pl>
+ */
+class CsrfCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (false === $container->hasDefinition('security.csrf.token_manager')) {
+            $container->removeDefinition('dunglas_angular_csrf.validation_listener');
+            $container->removeDefinition('dunglas_angular_csrf.form.extension.disable_csrf');
+            $container->removeDefinition('dunglas_angular_csrf.cookie_listener');
+            $container->removeDefinition('dunglas_angular_csrf.token_manager');
+        }
+    }
+}
+

--- a/DunglasAngularCsrfBundle.php
+++ b/DunglasAngularCsrfBundle.php
@@ -9,6 +9,8 @@
 
 namespace Dunglas\AngularCsrfBundle;
 
+use Dunglas\AngularCsrfBundle\DependencyInjection\CompilerPass\CsrfCompilerPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -16,4 +18,11 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class DunglasAngularCsrfBundle extends Bundle
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new CsrfCompilerPass());
+    }
 }

--- a/Features/Context/Fixtures/TestKernel.php
+++ b/Features/Context/Fixtures/TestKernel.php
@@ -29,6 +29,7 @@ class TestKernel extends Kernel
 
     public function __construct($config = 'default.yml')
     {
+        $this->name = 'app' . uniqid();
         parent::__construct('test', true);
 
         $fs = new Filesystem();
@@ -61,7 +62,7 @@ class TestKernel extends Kernel
 
     public function getCacheDir()
     {
-        return sys_get_temp_dir().'/DunglasAngularCsrfBundle/cache';
+        return sys_get_temp_dir().'/DunglasAngularCsrfBundle/cache/'. $this->name . $this->environment;
     }
 
     public function getLogDir()

--- a/Features/Context/Fixtures/config/csrf_protection_disabled.yml
+++ b/Features/Context/Fixtures/config/csrf_protection_disabled.yml
@@ -1,0 +1,33 @@
+framework:
+    secret: test
+    test: ~
+    session:
+        storage_id: session.storage.mock_file
+    form:            true
+    csrf_protection: false
+    profiler:        { only_exceptions: false }
+
+    validation:
+        enabled: true
+        enable_annotations: true
+    router:
+        resource: "%kernel.root_dir%/config/routing.yml"
+
+    templating:
+        engines: [twig, php]
+
+twig:
+    exception_controller:  twig.controller.exception:showAction
+    debug:            %kernel.debug%
+    strict_variables: %kernel.debug%
+
+dunglas_angular_csrf:
+    header:
+        name: X-XSRF-TOKEN
+    cookie:
+        set_on:
+            - { path: ^/$ }
+    secure:
+        - { path: ^/resource, methods: [POST, PUT, PATCH, LINK] }
+        - { path: ^/protected-resource, methods: [POST, PUT, PATCH, LINK] }
+

--- a/Features/ensuring_that_disabled_csrf_protection_doesnt_break_the_application.feature
+++ b/Features/ensuring_that_disabled_csrf_protection_doesnt_break_the_application.feature
@@ -1,0 +1,9 @@
+Feature: Ensuring that disabled CSRF protection doesn't break the application
+  In order to test functionally my application's forms
+  As a developer
+  I need to turn off the CSRF protection and things shouldn't break
+
+  Scenario: Sending request on protected route when csrf is disabled
+    Given I send POST request to "/resource" when csrf protection is disabled
+    Then the response code should be 201
+


### PR DESCRIPTION
So currently if u have application that uses some functional testing, there is a big chance that u 
have csrf protection disabled in your test environment. This PR will fix the issue, where there
is fatal error thrown whenver token manager isnt registered definition. 