### PR TITLE
Fix deprecation notice for symfony >2.7 for DisableCsrfExtension

### DIFF
--- a/Form/Extension/DisableCsrfExtension.php
+++ b/Form/Extension/DisableCsrfExtension.php
@@ -13,7 +13,7 @@ use Dunglas\AngularCsrfBundle\Csrf\AngularCsrfTokenManager;
 use Dunglas\AngularCsrfBundle\Routing\RouteMatcherInterface;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Form extension that disables the given forms' CSRF token validation
@@ -70,7 +70,7 @@ class DisableCsrfExtension extends AbstractTypeExtension
     /**
      * {@inheritdoc}
      */
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $request = $this->requestStack->getCurrentRequest();
         if (null === $request) {


### PR DESCRIPTION
This fixes deprecation notice:
```
DEPRECATED - Dunglas\AngularCsrfBundle\Form\Extension\DisableCsrfExtension: The FormTypeExtensionInterface::setDefaultOptions() method is deprecated since version 2.7 and will be removed in 3.0. Use configureOptions() instead. This method will be added to the FormTypeExtensionInterface with Symfony 3.0.  +
```