### PR TITLE
Use Zero Literally When Cookie Expiration is Zero

### DIFF
--- a/EventListener/AngularCsrfCookieListener.php
+++ b/EventListener/AngularCsrfCookieListener.php
@@ -98,7 +98,7 @@ class AngularCsrfCookieListener
         $event->getResponse()->headers->setCookie(new Cookie(
             $this->cookieName,
             $this->angularCsrfTokenManager->getToken()->getValue(),
-            time() + $this->cookieExpire,
+            0 === $this->cookieExpire ? $this->cookieExpire : time() + $this->cookieExpire,
             $this->cookiePath,
             $this->cookieDomain,
             $this->cookieSecure,

--- a/spec/Dunglas/AngularCsrfBundle/EventListener/AngularCsrfCookieListenerSpec.php
+++ b/spec/Dunglas/AngularCsrfBundle/EventListener/AngularCsrfCookieListenerSpec.php
@@ -13,6 +13,7 @@ use Dunglas\AngularCsrfBundle\Csrf\AngularCsrfTokenManager;
 use Dunglas\AngularCsrfBundle\Routing\RouteMatcherInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
@@ -35,6 +36,8 @@ class AngularCsrfCookieListenerSpec extends ObjectBehavior
     private $routes = array('^/punk', '^/rock$');
     private $secureRequest;
     private $unsecureRequest;
+    private $tokenManager;
+    private $routeMatcher;
 
     public function let(
         AngularCsrfTokenManager $tokenManager,
@@ -45,16 +48,18 @@ class AngularCsrfCookieListenerSpec extends ObjectBehavior
     ) {
         $token->getValue()->willReturn(self::TOKEN_VALUE);
         $tokenManager->getToken()->willReturn($token);
+        $this->tokenManager = $tokenManager;
 
         $this->secureRequest = $secureRequest;
         $this->unsecureRequest = $unsecureRequest;
 
         $routeMatcher->match($this->secureRequest, $this->routes)->willReturn(true);
         $routeMatcher->match($this->unsecureRequest, $this->routes)->willReturn(false);
+        $this->routeMatcher = $routeMatcher;
 
         $this->beConstructedWith(
-            $tokenManager,
-            $routeMatcher,
+            $this->tokenManager,
+            $this->routeMatcher,
             $this->routes,
             self::COOKIE_NAME,
             self::COOKIE_EXPIRE,
@@ -97,6 +102,58 @@ class AngularCsrfCookieListenerSpec extends ObjectBehavior
         $event->getRequestType()->willReturn(HttpKernelInterface::MASTER_REQUEST)->shouldBeCalled();
         $event->getRequest()->willReturn($this->unsecureRequest)->shouldBeCalled();
         $event->getResponse()->shouldNotBeCalled();
+
+        $this->onKernelResponse($event);
+    }
+
+    public function it_sets_a_cookie_with_no_expiration_when_cookie_expire_is_zero(
+        FilterResponseEvent $event,
+        Response $response,
+        ResponseHeaderBag $headers
+    ) {
+        $headers->setCookie(Argument::allOf(
+            Argument::type('Symfony\Component\HttpFoundation\Cookie'),
+            Argument::that(function (Cookie $c) {
+                return $c->getExpiresTime() === 0;
+            })
+        ))->shouldBeCalled();
+        $response->headers = $headers;
+
+        $event->getRequestType()->willReturn(HttpKernelInterface::MASTER_REQUEST)->shouldBeCalled();
+        $event->getRequest()->willReturn($this->secureRequest)->shouldBeCalled();
+        $event->getResponse()->willReturn($response)->shouldBeCalled();
+
+        $this->onKernelResponse($event);
+    }
+
+    public function it_sets_a_cookie_with_expiration_in_the_future_when_expiration_when_required(
+        CsrfToken $token,
+        FilterResponseEvent $event,
+        Response $response,
+        ResponseHeaderBag $headers
+    ) {
+        $headers->setCookie(Argument::allOf(
+            Argument::type('Symfony\Component\HttpFoundation\Cookie'),
+            Argument::that(function (Cookie $c) {
+                return $c->getExpiresTime() > time();
+            })
+        ))->shouldBeCalled();
+        $response->headers = $headers;
+
+        $this->beConstructedWith(
+            $this->tokenManager,
+            $this->routeMatcher,
+            $this->routes,
+            self::COOKIE_NAME,
+            3600,
+            self::COOKIE_PATH,
+            self::COOKIE_DOMAIN,
+            self::COOKIE_SECURE
+        );
+
+        $event->getRequestType()->willReturn(HttpKernelInterface::MASTER_REQUEST)->shouldBeCalled();
+        $event->getRequest()->willReturn($this->secureRequest)->shouldBeCalled();
+        $event->getResponse()->willReturn($response)->shouldBeCalled();
 
         $this->onKernelResponse($event);
     }


### PR DESCRIPTION
Otherwise add the cookie expiration to the current time. This means that
folks using the `0` in their bundle config will have a cookie that lasts
the length of the browser session. Everyone else will get a cookie that
expiers $cookieExpire seconds in the future.

Should fix #33 and address some of the concerns raised in #35 and the
commit 5479263a0aa78221d2350d52eb51d747e0ea7d33
