### PR TITLE
Added support for excluded routes

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -72,7 +72,17 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
-            ->end();
+                ->arrayNode('exclude')
+                    ->prototype('array')
+                        ->children()
+                            ->scalarNode('path')->defaultFalse()->end()
+                            ->scalarNode('route')->defaultFalse()->end()
+                            ->scalarNode('host')->defaultFalse()->end()
+                            ->arrayNode('methods')->prototype('scalar')->end()->end()
+                        ->end()
+                        ->end()
+                    ->end()
+                ->end();
 
         return $treeBuilder;
     }

--- a/DependencyInjection/DunglasAngularCsrfExtension.php
+++ b/DependencyInjection/DunglasAngularCsrfExtension.php
@@ -40,6 +40,7 @@ class DunglasAngularCsrfExtension extends Extension
         $container->setParameter('dunglas_angular_csrf.cookie.set_on', $config['cookie']['set_on']);
         $container->setParameter('dunglas_angular_csrf.header.name', $config['header']['name']);
         $container->setParameter('dunglas_angular_csrf.secure', $config['secure']);
+        $container->setParameter('dunglas_angular_csrf.exclude', $config['exclude']);
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');

--- a/EventListener/AngularCsrfValidationListener.php
+++ b/EventListener/AngularCsrfValidationListener.php
@@ -38,22 +38,29 @@ class AngularCsrfValidationListener
      * @var string
      */
     protected $headerName;
+    /**
+     * @var array
+     */
+    private $exclude;
 
     /**
      * @param AngularCsrfTokenManager $angularCsrfTokenManager
      * @param RouteMatcherInterface   $routeMatcher
      * @param array                   $routes
+     * @param array                   $exclude
      * @param string                  $headerName
      */
     public function __construct(
         AngularCsrfTokenManager $angularCsrfTokenManager,
         RouteMatcherInterface $routeMatcher,
         array $routes,
+        array $exclude,
         $headerName
     ) {
         $this->angularCsrfTokenManager = $angularCsrfTokenManager;
         $this->routeMatcher = $routeMatcher;
         $this->routes = $routes;
+        $this->exclude = $exclude;
         $this->headerName = $headerName;
     }
 
@@ -68,6 +75,8 @@ class AngularCsrfValidationListener
     {
         if (
             HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType()
+            ||
+            $this->routeMatcher->match($event->getRequest(), $this->exclude)
             ||
             !$this->routeMatcher->match($event->getRequest(), $this->routes)
         ) {

--- a/Features/Context/Fixtures/TestBundle/Controller/TestController.php
+++ b/Features/Context/Fixtures/TestBundle/Controller/TestController.php
@@ -37,4 +37,9 @@ class TestController extends Controller
 
         return new Response('Success', 400);
     }
+
+    public function csrfNonProtectedAction(Request $request)
+    {
+        return new Response('Success', 200);
+    }
 }

--- a/Features/Context/Fixtures/config/default.yml
+++ b/Features/Context/Fixtures/config/default.yml
@@ -30,3 +30,5 @@ dunglas_angular_csrf:
     secure:
         - { path: ^/resource, methods: [POST, PUT, PATCH, LINK] }
         - { path: ^/protected-resource, methods: [POST, PUT, PATCH, LINK] }
+    exclude:
+        - { path: ^/protected-resource/allowed, methods: [POST, PUT, PATCH, LINK] }

--- a/Features/Context/Fixtures/config/routing.yml
+++ b/Features/Context/Fixtures/config/routing.yml
@@ -9,3 +9,9 @@ test_csrf_protected_form:
     defaults: { _controller: TestBundle:Test:csrfProtected, _validate_csrf: true }
     requirements:
         _method: POST
+
+test_csrf_non_protected:
+    pattern:   /protected-resource/allowed
+    defaults: { _controller: TestBundle:Test:csrfNonProtected, _validate_csrf: true }
+    requirements:
+        _method: POST

--- a/Features/securing_endpoints.feature
+++ b/Features/securing_endpoints.feature
@@ -19,3 +19,7 @@ Feature: CSRF protection
   Scenario: The form csrf token is not disabled in favor of header one if its invalid
     Given I send POST request to "/protected-resource" with invalid csrf header
     Then the response code should be 403
+
+  Scenario: We should access excluded page which is behind secure
+    Given I send POST request to "/protected-resource/allowed" with invalid csrf header
+    Then the response code should be 200

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ dunglas_angular_csrf:
     # Patterns of URLs to check for a valid CSRF token
     secure:
         - { path: "^/url-pattern", route: "^route_name_pattern$", host: "example.com", methods: [GET, POST] }
+    # Patterns to exclude from secure routes
+    exclude:
+        - { path: "^/url-pattern/secured", route: "^route_name_pattern$", host: "example.com", methods: [GET, POST] }
 ```
 
 ## Integration with Symfony2 form component

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -24,6 +24,7 @@
             <argument type="service" id="dunglas_angular_csrf.token_manager" />
             <argument type="service" id="dunglas_angular_csrf.route_matcher" />
             <argument>%dunglas_angular_csrf.secure%</argument>
+            <argument>%dunglas_angular_csrf.exclude%</argument>
             <argument>%dunglas_angular_csrf.header.name%</argument>
 
             <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="12" />

--- a/spec/Dunglas/AngularCsrfBundle/DependencyInjection/DunglasAngularCsrfExtensionSpec.php
+++ b/spec/Dunglas/AngularCsrfBundle/DependencyInjection/DunglasAngularCsrfExtensionSpec.php
@@ -48,6 +48,9 @@ class DunglasAngularCsrfExtensionSpec extends ObjectBehavior
                     array('path' => '/bruay', 'route' => false, 'host' => false, 'methods' => array('HEAD', 'LINK')),
                     array('path' => false, 'route' => false, 'host' => 'example.com', 'methods' => array()),
                 ),
+                'exclude' => array(
+                    array('path' => '^/lille/allowed', 'route' => false, 'host' => false, 'methods' => array()),
+                ),
             ),
         );
 
@@ -63,6 +66,7 @@ class DunglasAngularCsrfExtensionSpec extends ObjectBehavior
         $container->setParameter('dunglas_angular_csrf.cookie.set_on', $configs['dunglas_angular_csrf']['cookie']['set_on'])->shouldBeCalled();
         $container->setParameter('dunglas_angular_csrf.header.name', $configs['dunglas_angular_csrf']['header']['name'])->shouldBeCalled();
         $container->setParameter('dunglas_angular_csrf.secure', $configs['dunglas_angular_csrf']['secure'])->shouldBeCalled();
+        $container->setParameter('dunglas_angular_csrf.exclude', $configs['dunglas_angular_csrf']['exclude'])->shouldBeCalled();
         $container->setDefinition('dunglas_angular_csrf.token_manager', Argument::type('Symfony\Component\DependencyInjection\Definition'))->shouldBeCalled();
         $container->setDefinition('dunglas_angular_csrf.route_matcher', Argument::type('Symfony\Component\DependencyInjection\Definition'))->shouldBeCalled();
         $container->setDefinition('dunglas_angular_csrf.validation_listener', Argument::type('Symfony\Component\DependencyInjection\Definition'))->shouldBeCalled();

--- a/spec/Dunglas/AngularCsrfBundle/EventListener/AngularCsrfValidationListenerSpec.php
+++ b/spec/Dunglas/AngularCsrfBundle/EventListener/AngularCsrfValidationListenerSpec.php
@@ -27,9 +27,11 @@ class AngularCsrfValidationListenerSpec extends ObjectBehavior
     const INVALID_TOKEN = 'invalid';
 
     private $routes = array('^/secured');
+    private $excluded = array('^/secured/allowed');
     private $secureValidRequest;
     private $secureInvalidRequest;
     private $unsecureRequest;
+    private $excludedSecureRequest;
 
     public function let(
         AngularCsrfTokenManager $tokenManager,
@@ -37,6 +39,7 @@ class AngularCsrfValidationListenerSpec extends ObjectBehavior
         Request $secureValidRequest,
         Request $secureInvalidRequest,
         Request $unsecureRequest,
+        Request $excludedSecureRequest,
         HeaderBag $validHeaders,
         HeaderBag $invalidHeaders
     ) {
@@ -52,12 +55,18 @@ class AngularCsrfValidationListenerSpec extends ObjectBehavior
         $this->secureInvalidRequest->headers = $invalidHeaders;
 
         $this->unsecureRequest = $unsecureRequest;
+        $this->excludedSecureRequest = $excludedSecureRequest;
 
         $routeMatcher->match($this->secureValidRequest, $this->routes)->willReturn(true);
+        $routeMatcher->match($this->secureValidRequest, $this->excluded)->willReturn(false);
         $routeMatcher->match($this->secureInvalidRequest, $this->routes)->willReturn(true);
+        $routeMatcher->match($this->secureInvalidRequest, $this->excluded)->willReturn(false);
         $routeMatcher->match($this->unsecureRequest, $this->routes)->willReturn(false);
+        $routeMatcher->match($this->unsecureRequest, $this->excluded)->willReturn(false);
+        $routeMatcher->match($this->excludedSecureRequest, $this->routes)->willReturn(true);
+        $routeMatcher->match($this->excludedSecureRequest, $this->excluded)->willReturn(true);
 
-        $this->beConstructedWith($tokenManager, $routeMatcher, $this->routes, self::HEADER_NAME);
+        $this->beConstructedWith($tokenManager, $routeMatcher, $this->routes, $this->excluded, self::HEADER_NAME);
     }
 
     public function it_is_initializable()
@@ -94,6 +103,14 @@ class AngularCsrfValidationListenerSpec extends ObjectBehavior
         $event->getRequestType()->willReturn(HttpKernelInterface::MASTER_REQUEST);
         $event->getRequest()->willReturn($this->unsecureRequest);
         $event->getResponse()->shouldNotBeCalled();
+
+        $this->onKernelRequest($event);
+    }
+
+    public function it_does_not_secure_when_it_is_excluded(GetResponseEvent $event)
+    {
+        $event->getRequestType()->willReturn(HttpKernelInterface::MASTER_REQUEST);
+        $event->getRequest()->willReturn($this->excludedSecureRequest);
 
         $this->onKernelRequest($event);
     }


### PR DESCRIPTION
Here I am trying to add exclusions to secure routes list. It's useful when you have situation when one  or couple routes from secured routes list needs to work without csrf protection.

Changes:
* New config option - exclude
* New array of excluded routes in AngularCsrfValidationListener
* Single behat test