### PR TITLE
Add config to receive XSRF in a cookie or session

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -40,6 +40,7 @@ class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->scalarNode('name')->cannotBeEmpty()->defaultValue('X-XSRF-TOKEN')->end()
+                        ->booleanNode('enabled')->defaultTrue()->end()
                     ->end()
                 ->end()
                 ->arrayNode('cookie')

--- a/DependencyInjection/DunglasAngularCsrfExtension.php
+++ b/DependencyInjection/DunglasAngularCsrfExtension.php
@@ -39,6 +39,7 @@ class DunglasAngularCsrfExtension extends Extension
         $container->setParameter('dunglas_angular_csrf.cookie.secure', $config['cookie']['secure']);
         $container->setParameter('dunglas_angular_csrf.cookie.set_on', $config['cookie']['set_on']);
         $container->setParameter('dunglas_angular_csrf.header.name', $config['header']['name']);
+        $container->setParameter('dunglas_angular_csrf.header.enabled', $config['header']['enabled']);
         $container->setParameter('dunglas_angular_csrf.secure', $config['secure']);
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));

--- a/EventListener/AngularCsrfValidationListener.php
+++ b/EventListener/AngularCsrfValidationListener.php
@@ -38,6 +38,14 @@ class AngularCsrfValidationListener
      * @var string
      */
     protected $headerName;
+    /**
+     * @var string
+     */
+    protected $headerEnabled;
+    /**
+     * @var string
+     */
+    protected $cookieName;
 
     /**
      * @param AngularCsrfTokenManager $angularCsrfTokenManager
@@ -49,12 +57,16 @@ class AngularCsrfValidationListener
         AngularCsrfTokenManager $angularCsrfTokenManager,
         RouteMatcherInterface $routeMatcher,
         array $routes,
-        $headerName
+        $headerName,
+        $headerEnabled,
+        $cookieName
     ) {
         $this->angularCsrfTokenManager = $angularCsrfTokenManager;
         $this->routeMatcher = $routeMatcher;
         $this->routes = $routes;
         $this->headerName = $headerName;
+        $this->headerEnabled = $headerEnabled;
+        $this->cookieName = $cookieName;
     }
 
     /**
@@ -74,7 +86,8 @@ class AngularCsrfValidationListener
             return;
         }
 
-        $value = $event->getRequest()->headers->get($this->headerName);
+        $request = $event->getRequest();
+        $value = $this->headerEnabled ? $request->headers->get($this->headerName) : $request->cookies->get($this->cookieName);
         if (!$value || !$this->angularCsrfTokenManager->isTokenValid($value)) {
             throw new AccessDeniedHttpException('Bad CSRF token.');
         }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -25,6 +25,8 @@
             <argument type="service" id="dunglas_angular_csrf.route_matcher" />
             <argument>%dunglas_angular_csrf.secure%</argument>
             <argument>%dunglas_angular_csrf.header.name%</argument>
+            <argument>%dunglas_angular_csrf.header.enabled%</argument>
+            <argument>%dunglas_angular_csrf.cookie.name%</argument>
 
             <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="12" />
         </service>


### PR DESCRIPTION
Adding the ability to disable the 'header' in the config. Doing this means the validation listener will listen for the cookie instead. I'm not using this with Angular, but it's extremely useful for any front-end it seems. My implementation is using VueJS, and although I can send the token in the header, it seems potentially more secure to save the XSRF value as a cookie from the express server with the httpOnly flag. Then the XHR request with axios will still post the token, but it will not be available in javascript.

(I'm also having a look into if I can accept signed cookies but I'm not sure I can right now).