### PR TITLE
Add Symfony 4.2 extended form type extensions

### DIFF
--- a/Form/Extension/DisableCsrfExtension.php
+++ b/Form/Extension/DisableCsrfExtension.php
@@ -14,6 +14,7 @@ use Dunglas\AngularCsrfBundle\Routing\RouteMatcherInterface;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 
 /**
  * Form extension that disables the given forms' CSRF token validation
@@ -95,6 +96,14 @@ class DisableCsrfExtension extends AbstractTypeExtension
      */
     public function getExtendedType()
     {
-        return 'Symfony\Component\Form\Extension\Core\Type\FormType';
+        return FormType::class;
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public static function getExtendedTypes()
+    {
+        yield FormType::class;
     }
 }


### PR DESCRIPTION
New in Symfony 4.2: https://symfony.com/blog/new-in-symfony-4-2-improved-form-type-extensions