### PR TITLE
Use Cookie::SAMESITE_NONE variable when setting cookie

### DIFF
--- a/EventListener/AngularCsrfCookieListener.php
+++ b/EventListener/AngularCsrfCookieListener.php
@@ -104,7 +104,7 @@ class AngularCsrfCookieListener
             $this->cookieSecure,
             false /* httpOnly */,
             false /* raw */,
-            Cookie::SAMESITE_LAX
+            Cookie::SAMESITE_NONE
         ));
     }
 }


### PR DESCRIPTION
Initially this looks like a strange PR for a bundle that does CSRF protection. 

However there are systems in the wild that do require this ie. legitimate loading of a cross-site iframe.

Yes, by having the site in an iframe and using 'None' cookies, you basically enable click-jacking.

However, you still can't make a cross-domain form submission or Ajax request, the cookie protects against that.

So if a site is designed to work in a frame the click-jacking is an accepted risk... but the cross-domain submissions are still something you want to protect against.

So to my mind, allowing CSRF None cookies is a legitimate use-case.